### PR TITLE
cg: always start line search with unit step length

### DIFF
--- a/src/unconstrained/cg.cpp
+++ b/src/unconstrained/cg.cpp
@@ -158,7 +158,7 @@ optim::internal::cg_impl(
 
         Vec_t d_p = - grad_p + beta*d;
 
-        t_init = t * (OPTIM_MATOPS_DOT_PROD(grad,d) / OPTIM_MATOPS_DOT_PROD(grad_p,d_p));
+        t_init = 1.0;
 
         grad = grad_p;
 


### PR DESCRIPTION
The example for Booth function fails with cg because the step length becomes 0. A remedy is to always start line search with a step length of 1.