### PR TITLE
bfgs: added missing inverse transform upon early return

### DIFF
--- a/src/unconstrained/bfgs.cpp
+++ b/src/unconstrained/bfgs.cpp
@@ -161,7 +161,12 @@ optim::internal::bfgs_impl(
     OPTIM_BFGS_TRACE(0, grad_err, rel_sol_change, x_p, d, grad_p, s, y, W);
 
     if (grad_err <= grad_err_tol) {
-        init_out_vals = x_p;
+    	if (vals_bound) {
+    	    init_out_vals = inv_transform(x_p, bounds_type, lower_bounds, upper_bounds);
+    	}
+    	else {
+            init_out_vals = x_p;
+        }
         return true;
     }
 


### PR DESCRIPTION
When bfgs returns after the initial line-search (before entering the main loop) and if constraints are used, an inverse transformation is missing.