### PR TITLE
Small error in example?

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ int main()
         std::cout << "de: Ackley test completed unsuccessfully." << std::endl;
     }
         
-    arma::cout << "de: solution to Ackley test:\n" << x << arma::endl;
+    std::cout << "de: solution to Ackley test:\n" << x << std::endl;
         
     return 0;
 }


### PR DESCRIPTION
Shouldn't it be `std::cout` and `std::endl`? That's at least the only way to make the Eigen example work on my computer.