### PR TITLE
Add cmake build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,71 @@
+cmake_minimum_required(VERSION 3.13)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+project(optim LANGUAGES CXX)
+
+set(ARCHITECTURE "x86" CACHE STRING "CPU Architecture [x86, ARM]")
+set(OPENMP ON CACHE BOOL "Enable OpenMP parallelization")
+set(FP_TYPE "double" CACHE STRING "Default floating point type")
+set(LINALG_LIB "eigen" CACHE STRING "Choice of linear algebra library [arma, eigen]")
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "The build type")
+
+include(FetchContent)
+
+FetchContent_Declare(
+  Eigen
+  GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
+  GIT_TAG 3.4.0
+  GIT_SHALLOW TRUE
+  GIT_PROGRESS TRUE)
+FetchContent_MakeAvailable(Eigen)
+
+# Optimization flags
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_compile_options(-O0 -g)
+else() # default to release
+    add_compile_options(
+        -O3 -ffp-contract=fast -flto -DNDEBUG -fPIC 
+    )
+
+    if(ARCHITECTURE STREQUAL "ARM")
+        add_compile_options(-mcpu=native)
+    else() # default to x86
+        add_compile_options(-march=native)
+    endif()
+
+    if(OPENMP)
+        add_compile_options(-fopenmp)
+    endif()
+endif()
+
+# Other flags
+
+if(LINALG_LIB STREQUAL "arma")
+    add_compile_options(-DOPTIM_ENABLE_ARMA_WRAPPERS -DARMA_NO_DEBUG)
+else() # default to eigen
+    add_compile_options(-DOPTIM_ENABLE_EIGEN_WRAPPERS)
+endif()
+
+add_compile_options(-Wall -DOPTIM_FPN_TYPE=${FP_TYPE} -lblas -llapack)
+
+add_library(optim SHARED
+    src/line_search/more_thuente.cpp
+    src/unconstrained/de.cpp
+    src/unconstrained/nm.cpp
+    src/unconstrained/newton.cpp
+    src/unconstrained/cg.cpp
+    src/unconstrained/bfgs.cpp
+    src/unconstrained/de_prmm.cpp
+    src/unconstrained/pso.cpp
+    src/unconstrained/pso_dv.cpp
+    src/unconstrained/gd.cpp
+    src/unconstrained/lbfgs.cpp
+    src/zeros/broyden.cpp
+    src/zeros/broyden_df.cpp
+    src/constrained/sumt.cpp
+)
+target_include_directories(optim PUBLIC include)
+target_link_libraries(optim Eigen3::Eigen)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,13 +15,17 @@ include(FetchContent)
 
 # Dependencies
 
-FetchContent_Declare(
-  Eigen
-  GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
-  GIT_TAG 3.4.0
-  GIT_SHALLOW TRUE
-  GIT_PROGRESS TRUE)
-FetchContent_MakeAvailable(Eigen)
+if(LINALG_LIB STREQUAL "arma")
+    find_package(Armadillo REQUIRED)
+else()
+    FetchContent_Declare(
+        Eigen
+        GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
+        GIT_TAG 3.4.0
+        GIT_SHALLOW TRUE
+        GIT_PROGRESS TRUE)
+    FetchContent_MakeAvailable(Eigen)
+endif()
 
 if(OPENMP)
     find_package(OpenMP REQUIRED)
@@ -72,7 +76,12 @@ add_library(optim SHARED
     src/constrained/sumt.cpp
 )
 target_include_directories(optim PUBLIC include)
-target_link_libraries(optim PRIVATE Eigen3::Eigen)
+if(LINALG_LIB STREQUAL "arma")
+    target_include_directories(optim PRIVATE ${ARMADILLO_INCLUDE_DIRS})
+    target_link_libraries(optim PRIVATE ${ARMADILLO_LIBRARIES})
+else()
+    target_link_libraries(optim PRIVATE Eigen3::Eigen)
+endif()
 if(OPENMP)
     target_link_libraries(optim PRIVATE OpenMP::OpenMP_CXX)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "The build type")
 
 include(FetchContent)
 
+# Dependencies
+
 FetchContent_Declare(
   Eigen
   GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
@@ -20,6 +22,10 @@ FetchContent_Declare(
   GIT_SHALLOW TRUE
   GIT_PROGRESS TRUE)
 FetchContent_MakeAvailable(Eigen)
+
+if(OPENMP)
+    find_package(OpenMP REQUIRED)
+endif()
 
 # Optimization flags
 
@@ -35,10 +41,6 @@ else() # default to release
     else() # default to x86
         add_compile_options(-march=native)
     endif()
-
-    if(OPENMP)
-        add_compile_options(-fopenmp)
-    endif()
 endif()
 
 # Other flags
@@ -50,6 +52,8 @@ else() # default to eigen
 endif()
 
 add_compile_options(-Wall -DOPTIM_FPN_TYPE=${FP_TYPE} -lblas -llapack)
+
+# Set up targets
 
 add_library(optim SHARED
     src/line_search/more_thuente.cpp
@@ -68,4 +72,7 @@ add_library(optim SHARED
     src/constrained/sumt.cpp
 )
 target_include_directories(optim PUBLIC include)
-target_link_libraries(optim Eigen3::Eigen)
+target_link_libraries(optim PRIVATE Eigen3::Eigen)
+if(OPENMP)
+    target_link_libraries(optim PRIVATE OpenMP::OpenMP_CXX)
+endif()


### PR DESCRIPTION
OptimLib doesn't provide any automated method for users to download and link against it, and in my opinion, doesn't integrate well into modern build systems. For example, my preferred method for including dependencies is using `FetchContent` with CMake to download and link against the dependencies without having to install it to the system, but this is not cleanly possible with OptimLib. Therefore, this PR adds a small `CMakeLists.txt` to this project, making it very easy to include in other CMake projects without having to build and install manually from source.

With this PR, building the Ackley example with CMake is as easy as:

```
cmake_minimum_required(VERSION 3.13)

set(CMAKE_CXX_STANDARD 14)
set(CMAKE_CXX_STANDARD_REQUIRED ON)

project(foo LANGUAGES CXX)

include(FetchContent)

FetchContent_Declare(
  Eigen
  GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
  GIT_TAG 3.4.0
  GIT_SHALLOW TRUE
  GIT_PROGRESS TRUE)
FetchContent_MakeAvailable(Eigen)

FetchContent_Declare(
  Optim
  GIT_REPOSITORY https://github.com/abhaybd/optim.git
  GIT_TAG add-cmake
  GIT_SHALLOW TRUE
  GIT_PROGRESS TRUE)
FetchContent_MakeAvailable(Optim)

add_executable(main main.cpp)
target_link_libraries(main PRIVATE Eigen3::Eigen optim)
```

Note that this example pulls from my fork, but if this PR is merged it should pull from the original repo and the `main` branch.

I'm not sure that I recreated all the compile-time flags properly, as the configure script was rather long, but I can confirm that this example does build and run correctly. If any flags aren't set properly, I'd welcome any modifications/fixes!