### PR TITLE
Fix namespace in newton_logit_reg.cpp

### DIFF
--- a/tests/unconstrained/newton_logit_reg.cpp
+++ b/tests/unconstrained/newton_logit_reg.cpp
@@ -87,7 +87,7 @@ int main()
     int n_dim = 5;     // dimension of theta
     int n_samp = 1000; // sample length
 
-    Mat_t X = optim::bmo::stats::rsnorm_mat<optim::fp_t>(n_samp,n_dim);
+    Mat_t X = bmo::stats::rsnorm_mat<optim::fp_t>(n_samp,n_dim);
     ColVec_t theta_0 = BMO_MATOPS_ARRAY_ADD_SCALAR(3.0 * BMO_MATOPS_RANDU_VEC(n_dim), 1.0);
 
     BMO_MATOPS_COUT << "\nTrue theta:\n" << theta_0 << "\n";


### PR DESCRIPTION
The `bmo` is introduced in `optim_options.hpp` outside the `optim::` namespace.

https://github.com/kthohr/optim/blob/248a927d6edee185f5fb6931e30051f9f1d2cf9e/include/misc/optim_options.hpp#L221

Removing the `optim::` allows this test to successfully build.